### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   run-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - run: bash .ci/runChecks.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   run-checks:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v5
       - run: bash .ci/runChecks.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   run-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/js-soft/ts-utils/security/code-scanning/3](https://github.com/js-soft/ts-utils/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`run-checks` and `test`) unless overridden. The minimal safe permission for this workflow is:

- `contents: read`

This preserves existing behavior (checkout/read operations still work) while enforcing least privilege for `GITHUB_TOKEN`.  
Change `.github/workflows/test.yml` near the top-level keys: insert `permissions:` between `on:` and `jobs:` (or anywhere at workflow root level).

No imports, methods, or extra definitions are needed—just YAML config update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
